### PR TITLE
Add Room type checking

### DIFF
--- a/SpeckleElementsRevit/ConversionRoutines/Room.cs
+++ b/SpeckleElementsRevit/ConversionRoutines/Room.cs
@@ -38,7 +38,8 @@ namespace SpeckleElementsRevit
       }
       speckleRoom.baseCurve = myPolyCurve;
       speckleRoom.parameters = GetElementParams( myRoom );
-      speckleRoom.typeParameters = GetElementTypeParams( myRoom );
+      if ( myRoom.IsValidType(myRoom.GetTypeId()) )
+        speckleRoom.typeParameters = GetElementTypeParams( myRoom );
 
       speckleRoom.ApplicationId = myRoom.UniqueId;
       speckleRoom.elementId = myRoom.Id.ToString();


### PR DESCRIPTION
Small patch for rooms: added checking for type parameters.
Spaces, rooms, zones and some other Revit elements don't have type class so we have to check for it before.
You can look at Autodesk.Revit.DB.ElementTypeGroup Enumeration https://www.revitapidocs.com/2020/f5b57d98-c551-9693-9009-8eb17fef8a14.htm